### PR TITLE
Fix find of non-term node

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -5,9 +5,7 @@
 // nodes that have letter values associated with them.
 package trie
 
-import (
-	"sort"
-)
+import "sort"
 
 type Node struct {
 	val      rune
@@ -75,7 +73,11 @@ func (t *Trie) Find(key string) (*Node, bool) {
 	if node == nil {
 		return nil, false
 	}
-	node = node.Children()[nul]
+
+	node, ok := node.Children()[nul]
+	if !ok {
+		return nil, false
+	}
 
 	if !node.term {
 		return nil, false

--- a/trie_test.go
+++ b/trie_test.go
@@ -49,6 +49,20 @@ func TestTrieFind(t *testing.T) {
 	}
 }
 
+func TestTrieFindMissingWithSubtree(t *testing.T) {
+	trie := New()
+	trie.Add("fooish", 1)
+	trie.Add("foobar", 1)
+
+	n, ok := trie.Find("foo")
+	if ok != false {
+		t.Errorf("Expected ok to be false")
+	}
+	if n != nil {
+		t.Errorf("Expected nil, got: %v", n)
+	}
+}
+
 func TestTrieFindMissing(t *testing.T) {
 	trie := New()
 


### PR DESCRIPTION
Non terminal nodes need to check for their [nul] children before using
them. Adding ("foobar" and "foodar") to trie creates the non-terminal
node "foo" which should not be 'findable'.
This used to cause a panic without the check for node,ok := children[nul]. which is fixed by this commit.