### PR TITLE
Optimize collect

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -53,16 +53,14 @@ func (t *Trie) Add(key string, meta interface{}) *Node {
 	bitmask := maskruneslice(runes)
 	node := t.root
 	node.mask |= bitmask
-	cp := make([]rune, 0, len(runes))
 	for i := range runes {
 		r := runes[i]
-		cp = append(cp, r)
 		bitmask = maskruneslice(runes[i:])
 		if n, ok := node.children[r]; ok {
 			node = n
 			node.mask |= bitmask
 		} else {
-			node = node.NewChild(r, string(cp), bitmask, nil, false)
+			node = node.NewChild(r, "", bitmask, nil, false)
 		}
 	}
 	node = node.NewChild(nul, key, 0, meta, true)

--- a/trie_test.go
+++ b/trie_test.go
@@ -310,6 +310,13 @@ func BenchmarkFuzzySearch(b *testing.B) {
 	}
 }
 
+func BenchmarkBuildTree(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		trie := New()
+		addFromFile(trie, "/usr/share/dict/words")
+	}
+}
+
 func TestSupportChinese(t *testing.T) {
 	trie := New()
 	expected := []string{"苹果 沂水县", "苹果", "大蒜", "大豆"}


### PR DESCRIPTION
Was
```
$ go test -bench . -benchtime 4s -benchmem
TieKeys-4        	 1000000	      8335 ns/op	     847 B/op	      67 allocs/op
PrefixSearch-4   	   10000	    617542 ns/op	   71653 B/op	    6287 allocs/op
FuzzySearch-4    	    1000	   8789504 ns/op	  793950 B/op	   52051 allocs/op
BuildTree-4      	      30	 172820241 ns/op	64263468 B/op	  908713 allocs/op
PASS
ok  	_trie	30.907s
```
And now its
```
$ go test -bench . -benchtime 4s -benchmem
TieKeys-4        	 1000000	      4583 ns/op	     566 B/op	       7 allocs/op
PrefixSearch-4   	   20000	    219790 ns/op	   33746 B/op	      16 allocs/op
FuzzySearch-4    	    1000	   5759077 ns/op	  479819 B/op	    5065 allocs/op
BuildTree-4      	      20	 240212152 ns/op	78269795 B/op	 1347616 allocs/op
PASS
ok  	_trie	24.888s
```

It's better than #16, but there's additional memory footprint and time to build trie.