### PR TITLE
Improve performance tuning slice capacity

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -53,16 +53,14 @@ func (t *Trie) Add(key string, meta interface{}) *Node {
 	bitmask := maskruneslice(runes)
 	node := t.root
 	node.mask |= bitmask
-	cp := make([]rune, 0, len(runes))
 	for i := range runes {
 		r := runes[i]
-		cp = append(cp, r)
 		bitmask = maskruneslice(runes[i:])
 		if n, ok := node.children[r]; ok {
 			node = n
 			node.mask |= bitmask
 		} else {
-			node = node.NewChild(r, string(cp), bitmask, nil, false)
+			node = node.NewChild(r, "", bitmask, nil, false)
 		}
 	}
 	node = node.NewChild(nul, key, 0, meta, true)

--- a/trie_test.go
+++ b/trie_test.go
@@ -310,6 +310,13 @@ func BenchmarkFuzzySearch(b *testing.B) {
 	}
 }
 
+func BenchmarkBuildTree(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		trie := New()
+		addFromFile(trie, "/usr/share/dict/words")
+	}
+}
+
 func TestSupportChinese(t *testing.T) {
 	trie := New()
 	expected := []string{"苹果 沂水县", "苹果", "大蒜", "大豆"}


### PR DESCRIPTION
I worked on top of #17.
* deleted unused function: Just to cleanup agreed on @derekparker review.
* created a count of leaves per node: this allows to create the `keys` slice in `collect` with the correct capacity to avoid allocations while `append`ing.
* in `collect` the `nodes` capacity is set to a lower-bound which save more allocations.

Here's the benchmark comparison to `master` now:
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkTieKeys-8          5098          2385          -53.22%
BenchmarkPrefixSearch-8     393791        118249        -69.97%
BenchmarkFuzzySearch-8      6001483       4151116       -30.83%

benchmark                   old allocs     new allocs     delta
BenchmarkTieKeys-8          56             3              -94.64%
BenchmarkPrefixSearch-8     5548           3              -99.95%
BenchmarkFuzzySearch-8      47089          8009           -82.99%

benchmark                   old bytes     new bytes     delta
BenchmarkTieKeys-8          840           256           -69.52%
BenchmarkPrefixSearch-8     71628         13120         -81.68%
BenchmarkFuzzySearch-8      793796        476874        -39.92%
```