### PR TITLE
avoid refer in Add and Remove

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -54,7 +54,6 @@ func (t *Trie) Root() *Node {
 // the caller.
 func (t *Trie) Add(key string, meta interface{}) *Node {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	t.size++
 	runes := []rune(key)
@@ -74,6 +73,8 @@ func (t *Trie) Add(key string, meta interface{}) *Node {
 		node.termCount++
 	}
 	node = node.NewChild(nul, key, 0, meta, true)
+	t.mu.Unlock()
+
 	return node
 }
 
@@ -106,9 +107,7 @@ func (t *Trie) Remove(key string) {
 		rs   = []rune(key)
 		node = findNode(t.Root(), []rune(key))
 	)
-
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	t.size--
 	for n := node.Parent(); n != nil; n = n.Parent() {
@@ -119,6 +118,7 @@ func (t *Trie) Remove(key string) {
 			break
 		}
 	}
+	t.mu.Unlock()
 }
 
 // Returns all the keys currently stored in the trie.

--- a/trie_test.go
+++ b/trie_test.go
@@ -350,3 +350,38 @@ func TestSupportChinese(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkAdd(b *testing.B) {
+	f, err := os.Open("/usr/share/dict/words")
+	if err != nil {
+		b.Fatal("couldn't open bag of words")
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	var words []string
+	for scanner.Scan() {
+		word := scanner.Text()
+		words = append(words, word)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trie := New()
+		for k := range words {
+			trie.Add(words[k], nil)
+		}
+	}
+}
+
+func BenchmarkAddRemove(b *testing.B) {
+	words := []string{"AAAA1", "AAAA2", "ABAA1", "AABA1", "ABAA2"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		trie := New()
+		for k := range words {
+			trie.Add(words[k], nil)
+		}
+		for k := range words {
+			trie.Remove(words[k])
+		}
+	}
+}


### PR DESCRIPTION
Closes #21 

Apart from the actual change, I added two new benchmarks to see the impact on `Add` and `Remove`.

Here's the comparison with `master` (with these added benchmarks):
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkTieKeys-8          2384          2391          +0.29%
BenchmarkPrefixSearch-8     118198        116171        -1.71%
BenchmarkFuzzySearch-8      4172439       4265630       +2.23%
BenchmarkBuildTree-8        120406301     115108497     -4.40%
BenchmarkAdd-8              117840555     112938392     -4.16%
BenchmarkAddRemove-8        7538          6616          -12.23%

benchmark                   old allocs     new allocs     delta
BenchmarkTieKeys-8          3              3              +0.00%
BenchmarkPrefixSearch-8     3              3              +0.00%
BenchmarkFuzzySearch-8      8009           8009           +0.00%
BenchmarkBuildTree-8        1010968        1010968        +0.00%
BenchmarkAdd-8              908710         908710         +0.00%
BenchmarkAddRemove-8        56             56             +0.00%

benchmark                   old bytes     new bytes     delta
BenchmarkTieKeys-8          256           256           +0.00%
BenchmarkPrefixSearch-8     13143         13121         -0.17%
BenchmarkFuzzySearch-8      475965        476646        +0.14%
BenchmarkBuildTree-8        76167905      76167968      +0.00%
BenchmarkAdd-8              75030785      75030708      -0.00%
BenchmarkAddRemove-8        4592          4592          +0.00%
```
In short, it improves both `Add` and `Remove`. The other differences seem quite volatile for me, but I encourage anyone to do the benchmarks again to double check.

My original tests for `Remove` involved using the `/usr/share/dict/words`, but I re-discovered that there's a bug when removing keys that aren't leafs in the trie. (I later saw that there was already an issue with a pending PR). 

