### PR TITLE
fix fuzzysearch on empty rune

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -265,6 +265,10 @@ type potentialSubtree struct {
 }
 
 func fuzzycollect(node *Node, partial []rune) []string {
+	if len(partial) == 0 {
+		return collect(node)
+	}
+
 	var (
 		m    uint64
 		i    int

--- a/trie_test.go
+++ b/trie_test.go
@@ -205,7 +205,6 @@ func TestPrefixSearch(t *testing.T) {
 }
 
 func TestFuzzySearch(t *testing.T) {
-	trie := New()
 	setup := []string{
 		"foosball",
 		"football",
@@ -230,18 +229,23 @@ func TestFuzzySearch(t *testing.T) {
 		{"fy", 1},
 		{"fz", 2},
 		{"a", 5},
+		{"", 8},
+		{"zzz", 0},
 	}
 
+	trie := New()
 	for _, key := range setup {
 		trie.Add(key, nil)
 	}
 
 	for _, test := range tests {
-		actual := trie.FuzzySearch(test.partial)
-		if len(actual) != test.length {
-			t.Errorf("Expected len(actual) to == %d, was %d for %s actual was %#v",
-				test.length, len(actual), test.partial, actual)
-		}
+		t.Run(test.partial, func(t *testing.T) {
+			actual := trie.FuzzySearch(test.partial)
+			if len(actual) != test.length {
+				t.Errorf("Expected len(actual) to == %d, was %d for %s actual was %#v",
+					test.length, len(actual), test.partial, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #18 

I preferred to make this case a direct exception than trying to pollute the logic and cpu cycles just to cover this case.

* fixes issue
* add two test cases: one for the issue and one with zero-results.