### PR TITLE
Fix panic during searches when trie is empty

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -246,7 +246,7 @@ func collect(node *Node) []string {
 		i int
 	)
 	keys := make([]string, 0, node.termCount)
-	nodes := make([]*Node, 1, len(node.children))
+	nodes := make([]*Node, 1, len(node.children)+1)
 	nodes[0] = node
 	for l := len(nodes); l != 0; l = len(nodes) {
 		i = l - 1

--- a/trie_test.go
+++ b/trie_test.go
@@ -213,6 +213,14 @@ func TestPrefixSearch(t *testing.T) {
 	trie.PrefixSearch("fsfsdfasdf")
 }
 
+func TestPrefixSearchEmpty(t *testing.T) {
+	trie := New()
+	keys := trie.PrefixSearch("")
+	if len(keys) != 0 {
+		t.Errorf("Expected 0 keys from empty trie, got: %d", len(keys))
+	}
+}
+
 func TestFuzzySearch(t *testing.T) {
 	setup := []string{
 		"foosball",
@@ -255,6 +263,14 @@ func TestFuzzySearch(t *testing.T) {
 					test.length, len(actual), test.partial, actual)
 			}
 		})
+	}
+}
+
+func TestFuzzySearchEmpty(t *testing.T) {
+	trie := New()
+	keys := trie.FuzzySearch("")
+	if len(keys) != 0 {
+		t.Errorf("Expected 0 keys from empty trie, got: %d", len(keys))
 	}
 }
 


### PR DESCRIPTION
make([]T, len, cap) panics if len > cap. The offending slice is already hardcoded to have starting length 1, so this change is the simplest way to ensure that the capacity is always valid. Per https://pkg.go.dev/builtin#make:

> A second integer argument may be provided to specify a different capacity; it must be no smaller than the length.

This fixes the issue described by https://github.com/go-delve/delve/issues/3217.